### PR TITLE
Initial add based MkDocs configuration to kickstart

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,8 @@
+# API Overview
+
+MLX-Audio exposes several modules for generating speech and running a web server.
+
+- `mlx_audio.tts.generate` – command line entry point and Python functions for TTS generation.
+- `mlx_audio.server` – launch the interactive web interface and REST API.
+
+For full details see the source code and docstrings.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,13 @@
+# MLX-Audio Documentation
+
+Welcome to **MLX-Audio**, a text-to-speech (TTS) and speech-to-speech (STS) library built on Apple's MLX framework.
+
+## Features
+
+- Fast inference on Apple Silicon
+- Multiple language and voice options
+- Adjustable speaking speed from 0.5x to 2.0x
+- Interactive web interface with 3D visualization
+- REST API for TTS generation
+- Quantization support for optimized performance
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,33 @@
+# Usage
+
+## Installation
+
+```bash
+pip install mlx-audio
+
+# For web interface and API dependencies
+pip install -r requirements.txt
+```
+
+## Command Line Example
+
+```bash
+# Basic usage
+mlx_audio.tts.generate --text "Hello, world"
+
+# Specify prefix for output file
+mlx_audio.tts.generate --text "Hello, world" --file_prefix hello
+
+# Adjust speaking speed
+mlx_audio.tts.generate --text "Hello, world" --speed 1.4
+```
+
+## Python Example
+
+```python
+from mlx_audio.tts.generate import generate_audio
+
+text = "The MLX King lives. Let him cook!"
+generate_audio(text=text)
+```
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,10 @@
+site_name: MLX-Audio
+nav:
+  - Home: index.md
+  - Usage: usage.md
+  - API: api.md
+markdown_extensions:
+  - toc
+  - tables
+plugins:
+  - search


### PR DESCRIPTION
## Context
We want to start a MKdocs documentation page for MLX-Audio.

## Description
Added MKdocs

## Changes in the codebase
None

## Changes outside the codebase
None

## Additional information
None

<!-- Optional: Add a checklist for contributors -->
## Checklist
- [ ] Tests added/updated
- [X] Documentation updated
- [ ] Issue referenced (e.g., Closes #123)