### PR TITLE
Fix path traversal vulnerability in server

### DIFF
--- a/mlx_audio/server.py
+++ b/mlx_audio/server.py
@@ -227,8 +227,13 @@ def get_audio_file(filename: str):
     Return an audio file from the outputs folder.
     The user can GET /audio/<filename> to fetch the WAV file.
     """
-    file_path = os.path.join(OUTPUT_FOLDER, filename)
+    file_path = os.path.abspath(os.path.join(OUTPUT_FOLDER, filename))
     logger.debug(f"Requested audio file: {file_path}")
+
+    # Prevent path traversal outside the OUTPUT_FOLDER
+    if not file_path.startswith(os.path.abspath(OUTPUT_FOLDER)):
+        logger.warning(f"Attempted path traversal: {file_path}")
+        return JSONResponse({"error": "Invalid file path"}, status_code=400)
 
     if not os.path.exists(file_path):
         logger.error(f"File not found: {file_path}")
@@ -349,7 +354,13 @@ def play_audio(filename: str = Form(...)):
     if audio_player is None:
         return JSONResponse({"error": "Audio player not initialized"}, status_code=500)
 
-    file_path = os.path.join(OUTPUT_FOLDER, filename)
+    file_path = os.path.abspath(os.path.join(OUTPUT_FOLDER, filename))
+
+    # Prevent path traversal outside the OUTPUT_FOLDER
+    if not file_path.startswith(os.path.abspath(OUTPUT_FOLDER)):
+        logger.warning(f"Attempted path traversal: {file_path}")
+        return JSONResponse({"error": "Invalid file path"}, status_code=400)
+
     if not os.path.exists(file_path):
         return JSONResponse({"error": "File not found"}, status_code=404)
 


### PR DESCRIPTION
## Summary
- sanitize user-provided filenames in server endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `mlx` and other deps)*

------
https://chatgpt.com/codex/tasks/task_e_6846a4c570148326a3a708bb9c2e2d33
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes path traversal vulnerability in `get_audio_file()` and `play_audio()` in `server.py` by validating file paths against `OUTPUT_FOLDER`.
> 
>   - **Security Fix**:
>     - Prevents path traversal in `get_audio_file()` and `play_audio()` in `server.py` by checking if the resolved file path starts with `OUTPUT_FOLDER`.
>     - Returns a 400 error with "Invalid file path" message if path traversal is detected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nlauchande%2Fmlx-audio&utm_source=github&utm_medium=referral)<sup> for e8db898fc99c8b8f0541a064281148f2a1c143e6. You can [customize](https://app.ellipsis.dev/nlauchande/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->